### PR TITLE
feat: simple negotiation env training support

### DIFF
--- a/spiral/agents/utils.py
+++ b/spiral/agents/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import re
+import random
 
 
 def kuhn_poker_parse_available_actions(observation: str):
@@ -42,9 +43,75 @@ def tic_tac_toe_parse_available_moves(observation: str):
     return available_moves
 
 
+def simple_negotiation_parse_available_actions(observation: str):
+    valid_actions = []
+
+    our_player_pattern = r"You are Player (\d+)"
+    our_player_match = re.search(our_player_pattern, observation)
+    if not our_player_match:
+        return ["I'll think about my strategy."]
+
+    our_player_id = int(our_player_match.group(1))
+
+    resources_pattern = r"\[(\w+)\]\s+Qty:\s+(\d+)"
+    resources = {}
+
+    for match in re.finditer(resources_pattern, observation):
+        resource_name = match.group(1)
+        quantity = int(match.group(2))
+        resources[resource_name] = quantity
+
+    offer_to_us_pattern = r"Player (\d+) made the following offer to Player (\d+):"
+    offer_matches = list(re.finditer(offer_to_us_pattern, observation))
+
+    if offer_matches:
+        last_offer = offer_matches[-1]
+        from_player = int(last_offer.group(1))
+        to_player = int(last_offer.group(2))
+
+        if to_player == our_player_id:
+            offer_position = last_offer.end()
+            remaining_text = observation[offer_position:]
+
+            if not re.search(r"(accepted|denied|implicitly denied)", remaining_text):
+                valid_actions.extend([
+                    "[Accept]",
+                    "[Deny]",
+                    "That sounds good to me. [Accept]",
+                    "I'll pass on this offer. [Deny]"
+                ])
+
+    if resources and len(resources) >= 2:
+        resource_names = list(resources.keys())
+
+        for _ in range(3):
+            offer_resource = random.choice(resource_names)
+            request_resource = random.choice([r for r in resource_names if r != offer_resource])
+
+            max_offer = min(3, resources[offer_resource])
+            if max_offer > 0:
+                offer_qty = random.randint(1, max_offer)
+                request_qty = random.randint(1, 3)
+
+                offer_str = f"[Offer: {offer_qty} {offer_resource} -> {request_qty} {request_resource}]"
+                valid_actions.append(offer_str)
+
+    chat_actions = [
+        "Let me think about what would be a fair trade.",
+        "What are you looking to trade?",
+        "I'm open to negotiation.",
+    ]
+    valid_actions.extend(chat_actions)
+
+    valid_actions = list(dict.fromkeys(valid_actions))
+
+    return valid_actions if valid_actions else ["I'll think about my options."]
+
+
 _VALID_ACTION_PARSER = {
     "TicTacToe-v0": tic_tac_toe_parse_available_moves,
     "KuhnPoker-v1": kuhn_poker_parse_available_actions,
+    "SimpleNegotiation-v1": simple_negotiation_parse_available_actions,
 }
 
 

--- a/train_spiral.py
+++ b/train_spiral.py
@@ -62,7 +62,7 @@ INVALID_ACTION = "[｜INVALID_ACTION｜]"
 @dataclass
 class SelfPlayArgs(PPOArgs):
     # Environment settings
-    env_id: Literal["TicTacToe-v0", "KuhnPoker-v1"] = "KuhnPoker-v1"
+    env_id: Literal["TicTacToe-v0", "KuhnPoker-v1", "SimpleNegotiation-v1"] = "KuhnPoker-v1"
     use_llm_obs_wrapper: bool = True  # Encode opponent history in the obs
 
     # Self-play specific settings
@@ -79,7 +79,7 @@ class SelfPlayArgs(PPOArgs):
     # Game evaluation
     eval_games: int = 16  # Number of games for evaluation
     eval_env_ids: List[str] = field(
-        default_factory=lambda: ["TicTacToe-v0", "KuhnPoker-v1"]
+        default_factory=lambda: ["TicTacToe-v0", "KuhnPoker-v1", "SimpleNegotiation-v1"]
     )
     eval_use_llm_obs_wrappers: List[bool] = field(default_factory=lambda: [False, True])
     eval_opponent_names: List[str] = field(
@@ -1003,6 +1003,10 @@ if __name__ == "__main__":
         assert (
             not args.use_llm_obs_wrapper
         ), "Please set --no-use_llm_obs_wrapper for TicTacToe-v0"
+    elif "SimpleNegotiation-v1" == args.env_id:
+        assert (
+            args.use_llm_obs_wrapper
+        ), "Please set --use_llm_obs_wrapper for SimpleNegotiation-v1"
     assert len(args.eval_env_ids) == len(args.eval_use_llm_obs_wrappers)
 
     # Let's go


### PR DESCRIPTION
This pull request introduces support for a new environment, `SimpleNegotiation-v1`, by adding parsing logic for its available actions and updating relevant configurations. The most significant changes include the implementation of a new action parser, updates to environment settings, and modifications to evaluation logic.

### Support for `SimpleNegotiation-v1` environment:

* **New action parser for `SimpleNegotiation-v1`:**
  - Implemented `simple_negotiation_parse_available_actions` in `spiral/agents/utils.py` to handle negotiation-based gameplay. This includes parsing player roles, resources, offers, and generating valid actions such as accepting/denying offers or proposing new ones.
  - Added `SimpleNegotiation-v1` to the `_VALID_ACTION_PARSER` dictionary for environment-specific action parsing.

* **Environment configuration updates:**
  - Updated the `env_id` field in `SelfPlayArgs` to include `SimpleNegotiation-v1` as a valid environment.
  - Added `SimpleNegotiation-v1` to the list of evaluation environments (`eval_env_ids`) in `SelfPlayArgs`.

* **Evaluation logic adjustments:**
  - Added an assertion in `run_self_play_rl` to enforce the use of `use_llm_obs_wrapper` for `SimpleNegotiation-v1`. This ensures proper encoding of opponent history during gameplay.