### PR TITLE
feat: add Tinker training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ export OPENROUTER_API_KEY=your_openrouter_key
 bash cmd/tinker/run_tinker_qwen3_4b.sh
 ```
 
+### Supported Models
+
+| Model | Script | Renderer | Notes |
+|-------|--------|----------|-------|
+| Qwen3-4B-Instruct | `cmd/tinker/run_tinker_qwen3_4b.sh` | `qwen3` | Recommended for quick experiments |
+| Llama-3-8B | `cmd/tinker/run_tinker_llama_8b.sh` | `llama_instruct` | |
+| GPT-OSS-20B | `cmd/tinker/run_tinker_gpt_oss_20b.sh` | `gpt_oss` | Reasoning MoE (small) |
+| GPT-OSS-120B | `cmd/tinker/run_tinker_gpt_oss_120b.sh` | `gpt_oss` | Reasoning MoE (medium), lower batch/LR |
+| Qwen3-8B-Base | `cmd/tinker/run_tinker_qwen3_8b_base.sh` | `qwen3_base` | Base (non-instruct) model |
+
 See [docs/TINKER.md](docs/TINKER.md) for full documentation including architecture details, hyperparameters, and advanced usage. For more information on the Tinker framework, see the [tinker-cookbook](https://github.com/tinker-engine/tinker-cookbook) repository.
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ cd evals/benchmarks
 bash batch_run.sh
 ```
 
+## Tinker Training
+
+SPIRAL now supports training with [Thinking Machine](https://thinkingmachine.ai/)'s **Tinker** distributed training framework. The `tinker/` addon provides a simplified synchronous training loop — no population-based self-play (FSP) or async actor-learner needed.
+
+### Quick Start
+
+```bash
+# Install with Tinker dependencies
+pip install -e ".[tinker]"
+
+# Set required environment variables
+export TINKER_API_KEY=your_tinker_key
+export WANDB_API_KEY=your_wandb_key
+export OPENROUTER_API_KEY=your_openrouter_key
+
+# Run training (Qwen3-4B)
+bash cmd/tinker/run_tinker_qwen3_4b.sh
+```
+
+See [docs/TINKER.md](docs/TINKER.md) for full documentation including architecture details, hyperparameters, and advanced usage. For more information on the Tinker framework, see the [tinker-cookbook](https://github.com/tinker-engine/tinker-cookbook) repository.
+
 ## Citation
 
 If you find our work useful for your research, please consider citing:
@@ -108,6 +129,7 @@ If you find our work useful for your research, please consider citing:
 
 ## Acknowledgement
 * This work is supported by [PlasticLabs](https://plasticlabs.ai/) and [Sea AI Lab](https://sail.sea.com/) for computing resources.
+* We thank [Thinking Machine](https://thinkingmachine.ai/) for providing compute credits for Tinker experiments.
 * The language games are sampled from [TextArena](https://github.com/LeonGuertler/TextArena), a collection of competitive text-based games for language model evaluation and reinforcement learning.
 * The multi-agent, multi-turn RL training is implemented with 🌾 [Oat](https://github.com/sail-sg/oat), a modular and research-friendly LLM RL framework.
 * We did exploration on PEFT experiments using [UnstableBaselines](https://github.com/LeonGuertler/UnstableBaselines), a lightweight, LoRA-first library for fast prototyping of self-play algorithms on TextArena.

--- a/cmd/tinker/run_tinker_gpt_oss_120b.sh
+++ b/cmd/tinker/run_tinker_gpt_oss_120b.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPIRAL Tinker addon — GPT-OSS-120B training script
+#
+# Usage:
+#   bash cmd/tinker/run_tinker_gpt_oss_120b.sh
+#
+# Required environment variables:
+#   TINKER_API_KEY      — Tinker service API key
+#   WANDB_API_KEY       — Weights & Biases API key
+#   OPENROUTER_API_KEY  — OpenRouter API key (for LLM eval opponents)
+
+set -euo pipefail
+
+# ── Validate environment ─────────────────────────────────────────────────────
+for var in TINKER_API_KEY WANDB_API_KEY OPENROUTER_API_KEY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set"
+        echo "  export $var=your_key"
+        exit 1
+    fi
+done
+
+export WEAVE_PRINT_CALL_LINK=false
+
+# ── Configurable defaults (override via env vars) ────────────────────────────
+MODEL_NAME="${MODEL_NAME:-openai/gpt-oss-120b}"
+RENDERER="${RENDERER:-gpt_oss}"
+LORA_RANK="${LORA_RANK:-16}"
+BATCH_SIZE="${BATCH_SIZE:-64}"
+NUM_TRAIN="${NUM_TRAIN:-51200}"
+LR="${LR:-2e-5}"
+MAX_TOKENS="${MAX_TOKENS:-8192}"
+ENV_IDS="${ENV_IDS:-TicTacToe-v0,KuhnPoker-v1,SimpleNegotiation-v2}"
+OBS_WRAPPERS="${OBS_WRAPPERS:-False,True,True}"
+EVAL_OPPONENTS="${EVAL_OPPONENTS:-google/gemini-2.0-flash-001}"
+WANDB_PROJECT="${WANDB_PROJECT:-spiral}"
+WANDB_NAME="${WANDB_NAME:-gpt-oss-120b-tinker-addon}"
+
+# ── Launch training ──────────────────────────────────────────────────────────
+python train_spiral_tinker.py \
+    model_name="$MODEL_NAME" \
+    renderer_name="$RENDERER" \
+    lora_rank="$LORA_RANK" \
+    env_ids="$ENV_IDS" \
+    use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    batch_size="$BATCH_SIZE" \
+    num_train_datapoints="$NUM_TRAIN" \
+    num_test_datapoints=128 \
+    learning_rate="$LR" \
+    max_tokens="$MAX_TOKENS" \
+    num_substeps=1 \
+    use_role_baseline=True \
+    role_baseline_ema_gamma=0.95 \
+    eval_env_ids="$ENV_IDS" \
+    eval_use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    eval_opponent_names="$EVAL_OPPONENTS" \
+    eval_every=16 \
+    save_every=20 \
+    loss_fn=importance_sampling \
+    wandb_project="$WANDB_PROJECT" \
+    wandb_name="$WANDB_NAME" \
+    use_streaming=false

--- a/cmd/tinker/run_tinker_gpt_oss_20b.sh
+++ b/cmd/tinker/run_tinker_gpt_oss_20b.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPIRAL Tinker addon — GPT-OSS-20B training script
+#
+# Usage:
+#   bash cmd/tinker/run_tinker_gpt_oss_20b.sh
+#
+# Required environment variables:
+#   TINKER_API_KEY      — Tinker service API key
+#   WANDB_API_KEY       — Weights & Biases API key
+#   OPENROUTER_API_KEY  — OpenRouter API key (for LLM eval opponents)
+
+set -euo pipefail
+
+# ── Validate environment ─────────────────────────────────────────────────────
+for var in TINKER_API_KEY WANDB_API_KEY OPENROUTER_API_KEY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set"
+        echo "  export $var=your_key"
+        exit 1
+    fi
+done
+
+export WEAVE_PRINT_CALL_LINK=false
+
+# ── Configurable defaults (override via env vars) ────────────────────────────
+MODEL_NAME="${MODEL_NAME:-openai/gpt-oss-20b}"
+RENDERER="${RENDERER:-gpt_oss}"
+LORA_RANK="${LORA_RANK:-32}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+NUM_TRAIN="${NUM_TRAIN:-51200}"
+LR="${LR:-4e-5}"
+MAX_TOKENS="${MAX_TOKENS:-8192}"
+ENV_IDS="${ENV_IDS:-TicTacToe-v0,KuhnPoker-v1,SimpleNegotiation-v2}"
+OBS_WRAPPERS="${OBS_WRAPPERS:-False,True,True}"
+EVAL_OPPONENTS="${EVAL_OPPONENTS:-google/gemini-2.0-flash-001}"
+WANDB_PROJECT="${WANDB_PROJECT:-spiral}"
+WANDB_NAME="${WANDB_NAME:-gpt-oss-20b-tinker-addon}"
+
+# ── Launch training ──────────────────────────────────────────────────────────
+python train_spiral_tinker.py \
+    model_name="$MODEL_NAME" \
+    renderer_name="$RENDERER" \
+    lora_rank="$LORA_RANK" \
+    env_ids="$ENV_IDS" \
+    use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    batch_size="$BATCH_SIZE" \
+    num_train_datapoints="$NUM_TRAIN" \
+    num_test_datapoints=128 \
+    learning_rate="$LR" \
+    max_tokens="$MAX_TOKENS" \
+    num_substeps=1 \
+    use_role_baseline=True \
+    role_baseline_ema_gamma=0.95 \
+    eval_env_ids="$ENV_IDS" \
+    eval_use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    eval_opponent_names="$EVAL_OPPONENTS" \
+    eval_every=16 \
+    save_every=20 \
+    loss_fn=importance_sampling \
+    wandb_project="$WANDB_PROJECT" \
+    wandb_name="$WANDB_NAME" \
+    use_streaming=false

--- a/cmd/tinker/run_tinker_llama_8b.sh
+++ b/cmd/tinker/run_tinker_llama_8b.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPIRAL Tinker addon — Llama-3-8B training script
+#
+# Usage:
+#   bash cmd/tinker/run_tinker_llama_8b.sh
+#
+# Required environment variables:
+#   TINKER_API_KEY      — Tinker service API key
+#   WANDB_API_KEY       — Weights & Biases API key
+#   OPENROUTER_API_KEY  — OpenRouter API key (for LLM eval opponents)
+
+set -euo pipefail
+
+# ── Validate environment ─────────────────────────────────────────────────────
+for var in TINKER_API_KEY WANDB_API_KEY OPENROUTER_API_KEY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set"
+        echo "  export $var=your_key"
+        exit 1
+    fi
+done
+
+export WEAVE_PRINT_CALL_LINK=false
+
+# ── Configurable defaults (override via env vars) ────────────────────────────
+MODEL_NAME="${MODEL_NAME:-meta-llama/Meta-Llama-3-8B}"
+RENDERER="${RENDERER:-llama_instruct}"
+LORA_RANK="${LORA_RANK:-64}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+NUM_TRAIN="${NUM_TRAIN:-51200}"
+LR="${LR:-4e-5}"
+MAX_TOKENS="${MAX_TOKENS:-16384}"
+ENV_IDS="${ENV_IDS:-TicTacToe-v0,KuhnPoker-v1,SimpleNegotiation-v2}"
+OBS_WRAPPERS="${OBS_WRAPPERS:-False,True,True}"
+EVAL_OPPONENTS="${EVAL_OPPONENTS:-google/gemini-2.0-flash-001}"
+WANDB_PROJECT="${WANDB_PROJECT:-spiral}"
+WANDB_NAME="${WANDB_NAME:-llama-8b-tinker-addon}"
+
+# ── Launch training ──────────────────────────────────────────────────────────
+python train_spiral_tinker.py \
+    model_name="$MODEL_NAME" \
+    renderer_name="$RENDERER" \
+    lora_rank="$LORA_RANK" \
+    env_ids="$ENV_IDS" \
+    use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    batch_size="$BATCH_SIZE" \
+    num_train_datapoints="$NUM_TRAIN" \
+    num_test_datapoints=128 \
+    learning_rate="$LR" \
+    max_tokens="$MAX_TOKENS" \
+    num_substeps=1 \
+    use_role_baseline=True \
+    role_baseline_ema_gamma=0.95 \
+    eval_env_ids="$ENV_IDS" \
+    eval_use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    eval_opponent_names="$EVAL_OPPONENTS" \
+    eval_every=16 \
+    save_every=20 \
+    loss_fn=importance_sampling \
+    wandb_project="$WANDB_PROJECT" \
+    wandb_name="$WANDB_NAME" \
+    use_streaming=false

--- a/cmd/tinker/run_tinker_qwen3_4b.sh
+++ b/cmd/tinker/run_tinker_qwen3_4b.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPIRAL Tinker addon — Qwen3-4B training script
+#
+# Usage:
+#   bash cmd/tinker/run_tinker_qwen3_4b.sh
+#
+# Required environment variables:
+#   TINKER_API_KEY      — Tinker service API key
+#   WANDB_API_KEY       — Weights & Biases API key
+#   OPENROUTER_API_KEY  — OpenRouter API key (for LLM eval opponents)
+
+set -euo pipefail
+
+# ── Validate environment ─────────────────────────────────────────────────────
+for var in TINKER_API_KEY WANDB_API_KEY OPENROUTER_API_KEY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set"
+        echo "  export $var=your_key"
+        exit 1
+    fi
+done
+
+export WEAVE_PRINT_CALL_LINK=false
+
+# ── Configurable defaults (override via env vars) ────────────────────────────
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-4B-Instruct-2507}"
+RENDERER="${RENDERER:-qwen3}"
+LORA_RANK="${LORA_RANK:-32}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+NUM_TRAIN="${NUM_TRAIN:-51200}"
+LR="${LR:-4e-5}"
+MAX_TOKENS="${MAX_TOKENS:-8192}"
+ENV_IDS="${ENV_IDS:-TicTacToe-v0,KuhnPoker-v1,SimpleNegotiation-v2}"
+OBS_WRAPPERS="${OBS_WRAPPERS:-False,True,True}"
+EVAL_OPPONENTS="${EVAL_OPPONENTS:-google/gemini-2.0-flash-001}"
+WANDB_PROJECT="${WANDB_PROJECT:-spiral}"
+WANDB_NAME="${WANDB_NAME:-qwen3-4b-tinker-addon}"
+
+# ── Launch training ──────────────────────────────────────────────────────────
+python train_spiral_tinker.py \
+    model_name="$MODEL_NAME" \
+    renderer_name="$RENDERER" \
+    lora_rank="$LORA_RANK" \
+    env_ids="$ENV_IDS" \
+    use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    batch_size="$BATCH_SIZE" \
+    num_train_datapoints="$NUM_TRAIN" \
+    num_test_datapoints=128 \
+    learning_rate="$LR" \
+    max_tokens="$MAX_TOKENS" \
+    num_substeps=1 \
+    use_role_baseline=True \
+    role_baseline_ema_gamma=0.95 \
+    eval_env_ids="$ENV_IDS" \
+    eval_use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    eval_opponent_names="$EVAL_OPPONENTS" \
+    eval_every=16 \
+    save_every=20 \
+    loss_fn=importance_sampling \
+    wandb_project="$WANDB_PROJECT" \
+    wandb_name="$WANDB_NAME" \
+    use_streaming=false

--- a/cmd/tinker/run_tinker_qwen3_8b_base.sh
+++ b/cmd/tinker/run_tinker_qwen3_8b_base.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPIRAL Tinker addon — Qwen3-8B-Base training script
+#
+# Usage:
+#   bash cmd/tinker/run_tinker_qwen3_8b_base.sh
+#
+# Required environment variables:
+#   TINKER_API_KEY      — Tinker service API key
+#   WANDB_API_KEY       — Weights & Biases API key
+#   OPENROUTER_API_KEY  — OpenRouter API key (for LLM eval opponents)
+
+set -euo pipefail
+
+# ── Validate environment ─────────────────────────────────────────────────────
+for var in TINKER_API_KEY WANDB_API_KEY OPENROUTER_API_KEY; do
+    if [ -z "${!var:-}" ]; then
+        echo "Error: $var is not set"
+        echo "  export $var=your_key"
+        exit 1
+    fi
+done
+
+export WEAVE_PRINT_CALL_LINK=false
+
+# ── Configurable defaults (override via env vars) ────────────────────────────
+MODEL_NAME="${MODEL_NAME:-Qwen/Qwen3-8B-Base}"
+RENDERER="${RENDERER:-qwen3_base}"
+LORA_RANK="${LORA_RANK:-64}"
+BATCH_SIZE="${BATCH_SIZE:-128}"
+NUM_TRAIN="${NUM_TRAIN:-51200}"
+LR="${LR:-4e-5}"
+MAX_TOKENS="${MAX_TOKENS:-8192}"
+ENV_IDS="${ENV_IDS:-TicTacToe-v0,KuhnPoker-v1,SimpleNegotiation-v2}"
+OBS_WRAPPERS="${OBS_WRAPPERS:-False,True,True}"
+EVAL_OPPONENTS="${EVAL_OPPONENTS:-google/gemini-2.0-flash-001}"
+WANDB_PROJECT="${WANDB_PROJECT:-spiral}"
+WANDB_NAME="${WANDB_NAME:-qwen3-8b-base-tinker-addon}"
+
+# ── Launch training ──────────────────────────────────────────────────────────
+python train_spiral_tinker.py \
+    model_name="$MODEL_NAME" \
+    renderer_name="$RENDERER" \
+    lora_rank="$LORA_RANK" \
+    env_ids="$ENV_IDS" \
+    use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    batch_size="$BATCH_SIZE" \
+    num_train_datapoints="$NUM_TRAIN" \
+    num_test_datapoints=128 \
+    learning_rate="$LR" \
+    max_tokens="$MAX_TOKENS" \
+    num_substeps=1 \
+    use_role_baseline=True \
+    role_baseline_ema_gamma=0.95 \
+    eval_env_ids="$ENV_IDS" \
+    eval_use_llm_obs_wrappers="$OBS_WRAPPERS" \
+    eval_opponent_names="$EVAL_OPPONENTS" \
+    eval_every=16 \
+    save_every=20 \
+    loss_fn=importance_sampling \
+    wandb_project="$WANDB_PROJECT" \
+    wandb_name="$WANDB_NAME" \
+    use_streaming=false

--- a/docs/TINKER.md
+++ b/docs/TINKER.md
@@ -1,0 +1,138 @@
+# SPIRAL Tinker Addon
+
+Simplified synchronous training for SPIRAL using the [Tinker](https://github.com/tinker-engine/tinker) distributed training framework.
+
+## Overview
+
+The `tinker/` addon provides a streamlined interface for running SPIRAL self-play RL training. It wraps the core `spiral.tinker` implementation with:
+
+- **Sync-only training** — no population-based self-play (FSP), no async actor-learner
+- **Flat module layout** — `tinker.training`, `tinker.env`, `tinker.rollouts`, etc.
+- **Ready-to-use bash scripts** — in `cmd/tinker/`
+
+## Quick Start
+
+### Prerequisites
+
+```bash
+pip install -e ".[tinker]"
+```
+
+This installs the core SPIRAL package plus Tinker dependencies (`tinker`, `tinker-cookbook`, `chz`).
+
+### Required Environment Variables
+
+```bash
+export TINKER_API_KEY=your_tinker_key
+export WANDB_API_KEY=your_wandb_key
+export OPENROUTER_API_KEY=your_openrouter_key   # for LLM eval opponents
+```
+
+### Run Training
+
+**Qwen3-4B (recommended for quick experiments):**
+
+```bash
+bash cmd/tinker/run_tinker_qwen3_4b.sh
+```
+
+**Llama-3-8B:**
+
+```bash
+bash cmd/tinker/run_tinker_llama_8b.sh
+```
+
+Both scripts accept overrides via environment variables:
+
+```bash
+BATCH_SIZE=64 LR=1e-4 ENV_IDS=KuhnPoker-v1 bash cmd/tinker/run_tinker_qwen3_4b.sh
+```
+
+### Direct Python Usage
+
+```bash
+python train_spiral_tinker.py \
+    model_name="Qwen/Qwen3-4B-Instruct-2507" \
+    renderer_name=qwen3 \
+    lora_rank=32 \
+    env_ids='KuhnPoker-v1' \
+    use_llm_obs_wrappers='True' \
+    batch_size=128 \
+    num_train_datapoints=12800 \
+    learning_rate=4e-5 \
+    max_tokens=8192
+```
+
+## Architecture
+
+```
+tinker/                        Top-level addon (simplified interface)
+├── __init__.py                Proxy + lazy exports
+├── training.py                Sync training loop (do_sync_training_spiral)
+├── dataset.py                 SpiralRLDataset / SpiralRLDatasetBuilder
+├── renderer.py                SpiralRenderer (boxed-action parsing)
+├── env.py                     TwoPlayerCoordinator + SpiralTwoPlayerEnv
+├── rollouts.py                Trajectory collection with draw retry
+├── train_step.py              Per-turn RAE advantage computation
+└── utils.py                   Logging, metrics
+
+spiral/                        Core package (unchanged)
+├── core/                      Shared components (envs, agents, utils)
+├── oat/                       OAT backend
+└── tinker/                    Full Tinker backend (FSP, async, eval)
+```
+
+### Import Paths
+
+```python
+# Addon (simplified)
+from tinker.training import create_spiral_train_loop
+
+# Core shared components
+from spiral.core import make_env, RandomAgent, EMA
+
+# Full Tinker backend (with FSP, async, eval)
+from spiral.tinker.training import PopulationManager
+```
+
+## Training Pipeline
+
+1. **Config** — `SpiralConfig` dataclass parsed via `chz` from CLI args
+2. **Dataset** — `SpiralRLDatasetBuilder` creates environment group builders for each game
+3. **Rollout** — Self-play trajectories collected with optional draw retry
+4. **Train step** — Per-turn advantages computed using Role-conditioned Advantage Estimation (RAE)
+5. **Eval** — Periodic async evaluation against random / LLM opponents
+
+### Key Hyperparameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `batch_size` | 128 | Must be even (2 players per game) |
+| `learning_rate` | 4e-5 | LoRA learning rate |
+| `lora_rank` | 32 | LoRA adapter rank |
+| `max_tokens` | 8192 | Max generation length |
+| `filter_draw` | False | Retry games that end in draws |
+| `max_draw_retries` | 5 | Max retries before accepting draw |
+| `use_role_baseline` | True | RAE: subtract per-role EMA baseline |
+| `role_baseline_ema_gamma` | 0.95 | EMA decay for role baselines |
+| `gamma` | 1.0 | Discount factor for earlier turns |
+| `eval_every` | 16 | Evaluate every N batches |
+
+### Supported Games
+
+- `TicTacToe-v0` — Classic tic-tac-toe
+- `KuhnPoker-v1` — Simplified poker
+- `SimpleNegotiation-v1` / `v2` — Resource negotiation
+- `LiarsDice-v1` — Bluffing dice
+- `TruthAndDeception-v1` — Deception game
+- `PigDice-v1` — Pig dice
+- `WordChains-v1` — Word chain
+- `SpellingBee-v1` — Spelling bee
+- `SimpleBlindAuction-v1` — Blind auction
+
+## What This Addon Does NOT Include
+
+- **Population-based self-play (FSP)** — use `spiral.tinker.training.population` directly
+- **Async actor-learner** — use `spiral.tinker.async_actor_learner`
+- **Complex eval runner** — use `spiral.tinker.eval` directly
+- **Math test evaluation** — available in `spiral.tinker.eval.math_test`

--- a/docs/TINKER.md
+++ b/docs/TINKER.md
@@ -42,7 +42,25 @@ bash cmd/tinker/run_tinker_qwen3_4b.sh
 bash cmd/tinker/run_tinker_llama_8b.sh
 ```
 
-Both scripts accept overrides via environment variables:
+**GPT-OSS-20B (reasoning MoE, small):**
+
+```bash
+bash cmd/tinker/run_tinker_gpt_oss_20b.sh
+```
+
+**GPT-OSS-120B (reasoning MoE, medium):**
+
+```bash
+bash cmd/tinker/run_tinker_gpt_oss_120b.sh
+```
+
+**Qwen3-8B-Base:**
+
+```bash
+bash cmd/tinker/run_tinker_qwen3_8b_base.sh
+```
+
+All scripts accept overrides via environment variables:
 
 ```bash
 BATCH_SIZE=64 LR=1e-4 ENV_IDS=KuhnPoker-v1 bash cmd/tinker/run_tinker_qwen3_4b.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,20 @@ dependencies = [
   "antlr4-python3-runtime==4.13.2"
 ]
 
+[project.optional-dependencies]
+tinker = [
+  "tinker",
+  "tinker-cookbook",
+  "chz",
+]
+
 [project.urls]
 Documentation = "https://github.com/spiral-ai/spiral#readme"
 Issues = "https://github.com/spiral-ai/spiral/issues"
 Source = "https://github.com/spiral-ai/spiral"
+
+[tool.hatch.build.targets.wheel]
+packages = ["spiral", "tinker"]
 
 [tool.hatch.version]
 path = "spiral/__about__.py"

--- a/tinker/__init__.py
+++ b/tinker/__init__.py
@@ -1,0 +1,126 @@
+"""SPIRAL Tinker addon - simplified sync training for the Tinker backend.
+
+This top-level package provides a streamlined interface for SPIRAL
+self-play training using Tinker. It wraps ``spiral.core`` shared
+components and offers sync-only training (no FSP, no async
+actor-learner).
+
+Because this directory shadows the pip-installed ``tinker`` package, the
+proxy below loads the pip package's exports so that existing code like
+``from tinker import ModelInput`` continues to work.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+
+# ── Proxy: expose pip-installed tinker alongside this local package ──────────
+
+
+def _load_pip_tinker():
+    """Find and load the pip-installed ``tinker`` package from site-packages."""
+    this_dir = os.path.dirname(os.path.abspath(__file__))
+    parent_dir = os.path.dirname(this_dir)
+
+    # 1. Remove local paths from sys.path so importlib finds the pip package
+    removed: list[tuple[int, str]] = []
+    idx = 0
+    while idx < len(sys.path):
+        p_abs = os.path.abspath(sys.path[idx]) if sys.path[idx] else os.path.abspath(".")
+        if p_abs == parent_dir:
+            removed.append((idx, sys.path.pop(idx)))
+        else:
+            idx += 1
+
+    # 2. Remove local tinker from sys.modules
+    saved: dict[str, object] = {}
+    for key in list(sys.modules):
+        if key == "tinker" or key.startswith("tinker."):
+            saved[key] = sys.modules.pop(key)
+
+    pip_mod = None
+    try:
+        pip_mod = importlib.import_module("tinker")
+    except ImportError:
+        pass
+    finally:
+        # Capture pip submodules before restoring local
+        pip_submodules = {
+            k: v for k, v in sys.modules.items() if k.startswith("tinker.")
+        }
+
+        # 3. Restore sys.path
+        for i, p in sorted(removed, key=lambda x: x[0]):
+            sys.path.insert(i, p)
+
+        # 4. Restore local module in sys.modules (overwrites pip entry)
+        for key, mod in saved.items():
+            sys.modules[key] = mod
+
+        # 5. Keep pip submodules accessible (don't overwrite local ones)
+        for key, mod in pip_submodules.items():
+            if key not in sys.modules:
+                sys.modules[key] = mod
+
+    return pip_mod
+
+
+_pip_tinker = _load_pip_tinker()
+
+if _pip_tinker is not None:
+    # Copy public attributes (ModelInput, TrainingClient, etc.)
+    for _attr in dir(_pip_tinker):
+        if not _attr.startswith("_"):
+            globals()[_attr] = getattr(_pip_tinker, _attr)
+
+    # Extend __path__ so pip submodules (tinker.types, etc.) are reachable
+    if hasattr(_pip_tinker, "__path__"):
+        for _p in _pip_tinker.__path__:
+            if _p not in __path__:
+                __path__.append(_p)
+
+# ── SPIRAL Tinker addon public API ───────────────────────────────────────────
+
+__all__ = [
+    "create_spiral_train_loop",
+    "do_sync_training_spiral",
+    "SpiralRLDataset",
+    "SpiralRLDatasetBuilder",
+    "SpiralRenderer",
+    "get_spiral_renderer",
+    "TwoPlayerCoordinator",
+    "SpiralTwoPlayerEnv",
+    "SpiralTwoPlayerEnvGroupBuilder",
+    "do_single_rollout",
+    "do_group_rollout",
+    "do_group_rollout_with_draw_retry",
+    "train_step",
+    "setup_logging",
+    "compute_trajectory_metrics",
+]
+
+
+def __getattr__(name: str):
+    """Lazy-load addon symbols to avoid circular imports at startup."""
+    _lazy_map = {
+        "create_spiral_train_loop": "tinker.training",
+        "do_sync_training_spiral": "tinker.training",
+        "SpiralRLDataset": "tinker.dataset",
+        "SpiralRLDatasetBuilder": "tinker.dataset",
+        "SpiralRenderer": "tinker.renderer",
+        "get_spiral_renderer": "tinker.renderer",
+        "TwoPlayerCoordinator": "tinker.env",
+        "SpiralTwoPlayerEnv": "tinker.env",
+        "SpiralTwoPlayerEnvGroupBuilder": "tinker.env",
+        "do_single_rollout": "tinker.rollouts",
+        "do_group_rollout": "tinker.rollouts",
+        "do_group_rollout_with_draw_retry": "tinker.rollouts",
+        "train_step": "tinker.train_step",
+        "setup_logging": "tinker.utils",
+        "compute_trajectory_metrics": "tinker.utils",
+    }
+    if name in _lazy_map:
+        mod = importlib.import_module(_lazy_map[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tinker/dataset.py
+++ b/tinker/dataset.py
@@ -1,0 +1,12 @@
+"""Simplified dataset builder for SPIRAL multi-environment training.
+
+Re-exports ``SpiralRLDataset`` and ``SpiralRLDatasetBuilder`` from
+``spiral.tinker.dataset``.
+"""
+
+from spiral.tinker.dataset import SpiralRLDataset, SpiralRLDatasetBuilder
+
+__all__ = [
+    "SpiralRLDataset",
+    "SpiralRLDatasetBuilder",
+]

--- a/tinker/env.py
+++ b/tinker/env.py
@@ -1,0 +1,18 @@
+"""Two-player game environment for SPIRAL self-play training with Tinker.
+
+Re-exports the core environment components from ``spiral.tinker.training.env``.
+"""
+
+from spiral.tinker.training.env import (
+    ILLEGAL_MOVE_REWARD,
+    SpiralTwoPlayerEnv,
+    SpiralTwoPlayerEnvGroupBuilder,
+    TwoPlayerCoordinator,
+)
+
+__all__ = [
+    "ILLEGAL_MOVE_REWARD",
+    "SpiralTwoPlayerEnv",
+    "SpiralTwoPlayerEnvGroupBuilder",
+    "TwoPlayerCoordinator",
+]

--- a/tinker/renderer.py
+++ b/tinker/renderer.py
@@ -1,6 +1,7 @@
 """Renderer for SPIRAL game observations.
 
-Re-exports the renderer components from ``spiral.tinker.renderer``.
+Re-exports the renderer components from ``spiral.tinker.renderer``
+and extends ``RENDERER_NAME_MAP`` with additional model aliases.
 """
 
 from spiral.tinker.renderer import (
@@ -9,6 +10,17 @@ from spiral.tinker.renderer import (
     SpiralRenderer,
     get_spiral_renderer,
 )
+
+# Extend RENDERER_NAME_MAP with aliases for additional model families.
+# GPT-OSS reasoning models use the Harmony chat format from tinker-cookbook.
+# Qwen3-Base models share the same tokenizer/format as Qwen3-Instruct.
+RENDERER_NAME_MAP.update({
+    "gpt_oss": "gpt_oss_medium_reasoning",
+    "gpt_oss_low": "gpt_oss_low_reasoning",
+    "gpt_oss_high": "gpt_oss_high_reasoning",
+    "gpt_oss_no_sysprompt": "gpt_oss_no_sysprompt",
+    "qwen3_base": "qwen3",
+})
 
 __all__ = [
     "INVALID_ACTION",

--- a/tinker/renderer.py
+++ b/tinker/renderer.py
@@ -1,0 +1,18 @@
+"""Renderer for SPIRAL game observations.
+
+Re-exports the renderer components from ``spiral.tinker.renderer``.
+"""
+
+from spiral.tinker.renderer import (
+    INVALID_ACTION,
+    RENDERER_NAME_MAP,
+    SpiralRenderer,
+    get_spiral_renderer,
+)
+
+__all__ = [
+    "INVALID_ACTION",
+    "RENDERER_NAME_MAP",
+    "SpiralRenderer",
+    "get_spiral_renderer",
+]

--- a/tinker/rollouts.py
+++ b/tinker/rollouts.py
@@ -1,0 +1,18 @@
+"""Trajectory collection with draw retry for SPIRAL.
+
+Re-exports rollout functions from ``spiral.tinker.training.rollouts``.
+"""
+
+from spiral.tinker.training.rollouts import (
+    do_group_rollout,
+    do_group_rollout_and_filter_constant_reward,
+    do_group_rollout_with_draw_retry,
+    do_single_rollout,
+)
+
+__all__ = [
+    "do_single_rollout",
+    "do_group_rollout",
+    "do_group_rollout_with_draw_retry",
+    "do_group_rollout_and_filter_constant_reward",
+]

--- a/tinker/train_step.py
+++ b/tinker/train_step.py
@@ -1,0 +1,8 @@
+"""Per-turn RAE advantage computation and training step.
+
+Re-exports the training step from ``spiral.tinker.training.train_step``.
+"""
+
+from spiral.tinker.training.train_step import train_step
+
+__all__ = ["train_step"]

--- a/tinker/training.py
+++ b/tinker/training.py
@@ -1,0 +1,222 @@
+"""Simplified synchronous training loop for SPIRAL with Tinker.
+
+This module provides ``create_spiral_train_loop`` and
+``do_sync_training_spiral`` — a streamlined sync-only training pipeline
+with no population-based self-play (FSP) and no async actor-learner.
+"""
+
+import asyncio
+import logging
+import re
+import time
+from typing import Optional
+
+import tinker
+from tinker_cookbook import checkpoint_utils
+from tinker_cookbook.rl import train
+from tinker_cookbook.rl.types import RLDataset, TrajectoryGroup
+from tinker_cookbook.tokenizer_utils import Tokenizer
+from tinker_cookbook.utils import ml_log
+from tinker_cookbook.utils.misc_utils import timed
+from tinker_cookbook.utils.trace import scope
+from tqdm.asyncio import tqdm
+
+from spiral.core.checkpoint_state import (
+    get_checkpoint_state,
+    get_checkpoint_state_path,
+    register_checkpoint_state,
+    restore_checkpoint_state,
+    save_checkpoint_state,
+)
+from spiral.tinker.eval.evaluator import AsyncEvalRunner
+from spiral.tinker.training.env import SpiralTwoPlayerEnvGroupBuilder
+from spiral.tinker.training.rollouts import (
+    do_group_rollout_and_filter_constant_reward,
+)
+from spiral.tinker.training.train_step import train_step as spiral_train_step
+from spiral.tinker.utils import convert_to_json_serializable, setup_logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+@scope
+async def do_sync_training_spiral(
+    start_batch: int,
+    end_batch: int,
+    num_batches: int,
+    cfg: train.Config,
+    training_client: tinker.TrainingClient,
+    service_client: tinker.ServiceClient,
+    evaluators: list,
+    dataset: RLDataset,
+    ml_logger: ml_log.Logger,
+    eval_runner: Optional[AsyncEvalRunner],
+    tokenizer: Tokenizer,
+):
+    """Synchronous on-policy training with draw retry (no FSP, no async).
+
+    Each iteration:
+      1. Save checkpoint (if due).
+      2. Collect self-play trajectories with optional draw retry.
+      3. Run custom SPIRAL train step (RAE advantages).
+      4. Log metrics.
+    """
+    for i_batch in range(start_batch, end_batch):
+        sampling_client, _ = await train.save_checkpoint_and_get_sampling_client(
+            training_client, i_batch + 1, cfg.log_path, cfg.save_every
+        )
+        if i_batch % cfg.save_every == 0:
+            logger.info(f"Saved checkpoint at batch {i_batch}")
+            state_path = get_checkpoint_state_path(
+                cfg.log_path, i_batch, name="training_state"
+            )
+            save_checkpoint_state(state_path)
+
+        metrics = {
+            "progress/batch": i_batch,
+            "optim/lr": cfg.learning_rate,
+            "progress/done_frac": (i_batch + 1) / num_batches,
+        }
+        t_start = time.time()
+
+        # Schedule async evaluation
+        if cfg.eval_every > 0 and i_batch % cfg.eval_every == 0 and eval_runner:
+            eval_runner.schedule_eval(evaluators, sampling_client, i_batch)
+
+        # Collect self-play trajectories
+        env_group_builders_P = dataset.get_batch(i_batch)
+        with timed("sample", metrics):
+            rollout_tasks = [
+                asyncio.create_task(
+                    do_group_rollout_and_filter_constant_reward(
+                        sampling_client,
+                        builder,
+                        max_tokens=cfg.max_tokens,
+                        do_remove_constant_reward_groups=cfg.remove_constant_reward_groups,
+                    ),
+                    name=f"sample_task_{i}",
+                )
+                for i, builder in enumerate(env_group_builders_P)
+            ]
+            trajectory_groups_P: list[TrajectoryGroup] = await tqdm.gather(
+                *rollout_tasks,
+                desc=f"Batch {i_batch} rollouts",
+            )
+
+        logger.info(
+            f"Training step {i_batch} with {len(trajectory_groups_P)} trajectory groups"
+        )
+
+        # Train step with RAE advantages
+        train_step_metrics = await spiral_train_step(
+            cfg,
+            i_batch,
+            training_client,
+            tokenizer,
+            env_group_builders_P,
+            trajectory_groups_P,
+            sampling_client,
+        )
+
+        metrics.update(train_step_metrics)
+        metrics["time/total"] = time.time() - t_start
+        metrics = convert_to_json_serializable(metrics)
+        ml_logger.log_metrics(metrics, step=i_batch)
+
+
+async def create_spiral_train_loop(cfg: train.Config):
+    """Main training loop for SPIRAL using Tinker (sync-only, no FSP).
+
+    1. Set up logging (training + optional separate eval logger).
+    2. Resume from checkpoint if available.
+    3. Create LoRA training client.
+    4. Build dataset and evaluators.
+    5. Run ``do_sync_training_spiral``.
+    """
+    # Set up loggers
+    ml_logger = setup_logging(
+        log_dir=cfg.log_path,
+        wandb_project=cfg.wandb_project,
+        config=cfg,
+        wandb_name=cfg.wandb_name,
+    )
+    eval_logger = None
+    eval_runner = None
+    if cfg.eval_every > 0 and cfg.wandb_project:
+        eval_wandb_name = f"{cfg.wandb_name}_eval" if cfg.wandb_name else None
+        eval_logger = setup_logging(
+            log_dir=cfg.log_path,
+            wandb_project=cfg.wandb_project,
+            config=cfg,
+            wandb_name=eval_wandb_name,
+            reinit="create_new",
+        )
+        eval_runner = AsyncEvalRunner(eval_logger)
+
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("pylatexenc").setLevel(logging.WARNING)
+
+    # Determine start batch
+    resume_info = checkpoint_utils.get_last_checkpoint(cfg.log_path)
+    if resume_info:
+        start_batch = resume_info["batch"]
+    elif hasattr(cfg, "load_checkpoint_path") and cfg.load_checkpoint_path:
+        match = re.search(r"/weights/(\d{6})$", cfg.load_checkpoint_path)
+        start_batch = int(match.group(1)) if match else 0
+    else:
+        start_batch = 0
+
+    service_client = tinker.ServiceClient(base_url=cfg.base_url)
+    register_checkpoint_state(
+        "role_baselines", SpiralTwoPlayerEnvGroupBuilder._role_baseline_emas
+    )
+
+    # Resume or create training client
+    load_state_path = (
+        resume_info["state_path"] if resume_info else getattr(cfg, "load_checkpoint_path", None)
+    )
+    if load_state_path:
+        logger.info(f"Resuming from {load_state_path} at batch {start_batch}")
+        training_client = await service_client.create_training_client_from_state_async(
+            path=load_state_path, user_metadata=None
+        )
+        if start_batch > 0:
+            ema_path = getattr(cfg, "ema_resume_path", None)
+            state_path = ema_path or get_checkpoint_state_path(
+                cfg.log_path, start_batch, name="training_state"
+            )
+            restore_checkpoint_state(state_path)
+            restored = get_checkpoint_state("role_baselines")
+            if restored is not None:
+                SpiralTwoPlayerEnvGroupBuilder._role_baseline_emas = restored
+    else:
+        training_client = await service_client.create_lora_training_client_async(
+            cfg.model_name, rank=cfg.lora_rank
+        )
+
+    tokenizer = training_client.get_tokenizer()
+    dataset, _ = await cfg.dataset_builder()
+    evaluators = [eb() for eb in cfg.evaluator_builders]
+
+    num_batches = len(dataset)
+    logger.info(f"Training for {num_batches} batches (sync mode, no FSP)")
+
+    await do_sync_training_spiral(
+        start_batch=start_batch,
+        end_batch=num_batches,
+        num_batches=num_batches,
+        cfg=cfg,
+        training_client=training_client,
+        service_client=service_client,
+        evaluators=evaluators,
+        dataset=dataset,
+        ml_logger=ml_logger,
+        eval_runner=eval_runner,
+        tokenizer=tokenizer,
+    )
+
+    ml_logger.close()
+    if eval_logger:
+        eval_logger.close()
+    logger.info("Training completed successfully")

--- a/tinker/utils.py
+++ b/tinker/utils.py
@@ -1,0 +1,16 @@
+"""Logging and metrics utilities for SPIRAL Tinker training.
+
+Re-exports utility functions from ``spiral.tinker.utils``.
+"""
+
+from spiral.tinker.utils import (
+    compute_trajectory_metrics,
+    convert_to_json_serializable,
+    setup_logging,
+)
+
+__all__ = [
+    "setup_logging",
+    "compute_trajectory_metrics",
+    "convert_to_json_serializable",
+]


### PR DESCRIPTION
## Summary

- Adds a top-level `tinker/` package as a simplified addon for SPIRAL training via the Tinker distributed training framework
- Imports shared components from `spiral.tinker` internals with a flat module layout (`tinker.training`, `tinker.env`,
`tinker.rollouts`, etc.)
- Includes ready-to-use bash scripts for Qwen3-4B, Llama-8B, Qwen3-8B-Base, GPT-OSS-20B, and GPT-OSS-120B in `cmd/tinker/`
- Adds `[tinker]` optional dependency group to `pyproject.toml`
- Full documentation in `docs/TINKER.md`
- README updated with Tinker training quick-start section and Thinking Machine acknowledgement

## New files

| File | Purpose |
|------|---------|
| `tinker/__init__.py` | Proxy init that transparently bridges pip tinker + addon exports |
| `tinker/training.py` | Simplified sync training loop (`create_spiral_train_loop`, `do_sync_training_spiral`) |
| `tinker/dataset.py` | Re-exports `SpiralRLDataset` / `SpiralRLDatasetBuilder` |
| `tinker/renderer.py` | Re-exports `SpiralRenderer` / `get_spiral_renderer` |
| `tinker/env.py` | Re-exports `TwoPlayerCoordinator`, `SpiralTwoPlayerEnv`, `SpiralTwoPlayerEnvGroupBuilder` |
| `tinker/rollouts.py` | Re-exports trajectory collection functions with draw retry |
| `tinker/train_step.py` | Re-exports per-turn RAE advantage train step |
| `tinker/utils.py` | Re-exports logging and metrics utilities |
| `cmd/tinker/run_tinker_qwen3_4b.sh` | Bash script for Qwen3-4B-Instruct training |
| `cmd/tinker/run_tinker_llama_8b.sh` | Bash script for Llama-3.1-8B training |
| `cmd/tinker/run_tinker_qwen3_8b_base.sh` | Bash script for Qwen3-8B-Base training |
| `cmd/tinker/run_tinker_gpt_oss_20b.sh` | Bash script for OpenAI GPT-OSS-20B training |
| `cmd/tinker/run_tinker_gpt_oss_120b.sh` | Bash script for OpenAI GPT-OSS-120B training |
| `docs/TINKER.md` | Full documentation (quick start, architecture, hyperparameters) |

## Test plan

- [X] `pip install -e ".[tinker]"` installs successfully
- [X] `bash cmd/tinker/run_tinker_qwen3_4b.sh` runs training
- [X] `from tinker.training import create_spiral_train_loop` imports correctly
- [X] Existing `spiral/` imports are unaffected